### PR TITLE
Patch update for users

### DIFF
--- a/curl.md
+++ b/curl.md
@@ -22,5 +22,7 @@
 * `curl -H "jwt: <YOUR JWT TOKEN>" https://exp-starter-api.herokuapp.com/users/<ANY VALID USER ID>`
 
 ##### update
+This is a patch type update, so just send the stuff that is different!
+
 * `curl -X PUT -H "jwt: <YOUR JWT TOKEN>" -H "Content-Type: application/json" -d '{"email":"freyja@example.com", "password": "password", "firstName": "Freyja", "lastName": "Platzer Bartel", "birthYear": "2016", "student": "false"}' http://localhost:3000/users/<YOUR USER ID>`
 * `curl -X PUT -H "jwt: <YOUR JWT TOKEN>" -H "Content-Type: application/json" -d '{"email":"freyja@example.com", "password": "password", "firstName": "Freyja", "lastName": "Platzer Bartel", "birthYear": "2016", "student": "false"}' https://exp-starter-api.herokuapp.com/users/<YOUR USER ID>`

--- a/test/features/users.test.js
+++ b/test/features/users.test.js
@@ -154,22 +154,17 @@ describe('Users', () => {
       .set('jwt', selfToken)
       .send({
         firstName: 'Elowyn',
-        lastName: 'Platzer Bartel',
-        email: 'elowyn@example.com',
-        birthYear: 2015,
-        student: true,
-        password: 'password',
       })
       .expect(200);
 
     expect(resSelf.body.user.firstName).toBe('Elowyn');
-    expect(resSelf.body.user.lastName).toBe('Platzer Bartel');
-    expect(resSelf.body.user.email).toBe('elowyn@example.com');
-    expect(resSelf.body.user.birthYear).toBe(2015);
-    expect(resSelf.body.user.student).toBe(true);
+    expect(resSelf.body.user.lastName).toBe(self.lastName);
+    expect(resSelf.body.user.email).toBe(self.email);
+    expect(resSelf.body.user.birthYear).toBe(self.birthYear);
+    expect(resSelf.body.user.student).toBe(self.student);
   });
 
-  it('can update to using own pre-existing email address', async () => {
+  it('can update to with same pre-existing email address', async () => {
     const user = await createUser();
     const serializedSecondUser = await userSerializer(user);
     const token = jwt.sign({ user: serializedSecondUser }, process.env.JWT_SECRET);
@@ -179,21 +174,16 @@ describe('Users', () => {
       .set('jwt', token)
       .send({
         firstName: 'Elowyn',
-        lastName: 'Platzer Bartel',
-        email: user.email,
-        birthYear: 2015,
-        student: true,
-        password: 'password',
       })
       .expect(200);
 
     expect(res.body.user).toEqual({
       id: user.id,
-      birthYear: 2015,
+      birthYear: user.birthYear,
       email: user.email,
       firstName: 'Elowyn',
-      lastName: 'Platzer Bartel',
-      student: true
+      lastName: user.lastName,
+      student: user.student
     });
   });
 
@@ -207,30 +197,10 @@ describe('Users', () => {
       .put(`/users/${secondUser.id}`)
       .set('jwt', token)
       .send({
-        firstName: 'Elowyn',
-        lastName: 'Other Person',
         email: firstUser.email,
-        birthYear: 2000,
-        student: true,
-        password: 'password',
       })
       .expect(200);
 
     expect(res.body.user).toEqual({ errors: ['Email already taken'] });
-  });
-
-  it('should trim email whitespaces and down case the email', async () => {
-    const user = await createUser({ email: '  ElowYn@example.com '});
-    const serializedUser = await userSerializer(user);
-    const token = jwt.sign({ user: serializedUser }, process.env.JWT_SECRET);
-
-    const resLoggedIn = await request(app)
-      .get('/users')
-      .set('jwt', token)
-      .expect(200);
-
-    expect(resLoggedIn.body.users.length).toEqual(1);
-    const newUser = resLoggedIn.body.users[0];
-    expect(newUser.email).toEqual('elowyn@example.com');
   });
 });

--- a/test/models/user.test.js
+++ b/test/models/user.test.js
@@ -44,6 +44,27 @@ describe('User', () => {
     expect(users.length).toBe(1);
   });
 
+
+  it('removes email whitespaces, down cases on create/update ', async () => {
+    const user = await User.create({
+      firstName: 'Elowyn',
+      lastName: 'Platzer Bartel',
+      email: '  ElowYn@example.com ',
+      birthYear: 2015,
+      student: true,
+      password: 'password',
+    });
+
+    expect(user.email).toEqual('elowyn@example.com');
+
+    const updatedUser = await User.update({
+      id: user.id,
+      email: '  ElowYn@example.com ',
+    });
+
+    expect(updatedUser.email).toEqual('elowyn@example.com');
+  });
+
   it('can be updated', async () => {
     const originalUser = await User.create({
       firstName: 'Elowyn',


### PR DESCRIPTION
### What does this PR do?

This PR turns the user update into more of a patch-style update. This allows users to only send the properties that have been changed, and allows users to be updated without having to change their password EVERY TIME.

![giphy-downsized 25](https://user-images.githubusercontent.com/6353499/32115360-c2f3e76e-bb03-11e7-871e-8a31156bd4a5.gif)


Also moved the email whitespace and downcase test to the model test, and found that update wasn't using the function. Now update emails get cleaned up too!

### Where should someone start to review?

"top" of user update function.

### How could you test this PR's functionality?

curl it

### ~~New dependencies?~~

### Gif of your feels

![giphy-downsized 26](https://user-images.githubusercontent.com/6353499/32115444-14d0f0fe-bb04-11e7-94ca-8dbf9cc966c2.gif)

