### PR TITLE
Added /me route and removed user details from jwt token

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 
+const currentUser = require('../lib/currentUser');
 const userSerializer = require('../serializers/user');
 const User = require('../models/user');
 
@@ -7,6 +8,12 @@ exports.index = async (req, res, next) => {
   const users = await User.all();
   const serializedUsers = users.map(user => userSerializer(user));
   res.json({ users: await Promise.all(serializedUsers) });
+};
+
+exports.me = async (req, res, next) => {
+  const token = req.headers.jwt;
+  const user = await currentUser(token);
+  res.json({ user: user });
 };
 
 exports.create = async (req, res, next) => {

--- a/curl.md
+++ b/curl.md
@@ -26,3 +26,7 @@ This is a patch type update, so just send the stuff that is different!
 
 * `curl -X PUT -H "jwt: <YOUR JWT TOKEN>" -H "Content-Type: application/json" -d '{"email":"freyja@example.com", "password": "password", "firstName": "Freyja", "lastName": "Platzer Bartel", "birthYear": "2016", "student": "false"}' http://localhost:3001/users/<YOUR USER ID>`
 * `curl -X PUT -H "jwt: <YOUR JWT TOKEN>" -H "Content-Type: application/json" -d '{"email":"freyja@example.com", "password": "password", "firstName": "Freyja", "lastName": "Platzer Bartel", "birthYear": "2016", "student": "false"}' https://exp-starter-api.herokuapp.com/users/<YOUR USER ID>`
+
+##### me
+* `curl -H "jwt: <YOUR JWT TOKEN>" http://localhost:3001/users/me`
+* `curl -H "jwt: <YOUR JWT TOKEN>" https://exp-starter-api.herokuapp.com/users/users/me`

--- a/models/user.js
+++ b/models/user.js
@@ -21,7 +21,7 @@ exports.authenticate = async credentials => {
 
   if (valid) {
     const serializedUser = await userSerializer(user);
-    const token = jwt.sign({ user: serializedUser }, process.env.JWT_SECRET);
+    const token = jwt.sign({ currentUserId: user.id }, process.env.JWT_SECRET);
     return { jwt: token, user: serializedUser };
   } else {
     return { errors: ['Email or Password is incorrect'] };
@@ -70,21 +70,21 @@ exports.findBy = async property => {
   const key = Object.keys(property)[0];
   let findByQuery;
   switch (key) {
-  case 'firstName':
-    findByQuery = 'SELECT * FROM "users" WHERE "firstName" = $1 LIMIT 1';
-    break;
-  case 'lastName':
-    findByQuery = 'SELECT * FROM "users" WHERE "lastName" = $1 LIMIT 1';
-    break;
-  case 'email':
-    findByQuery = 'SELECT * FROM "users" WHERE "email" = $1 LIMIT 1';
-    break;
-  case 'birthYear':
-    findByQuery = 'SELECT * FROM "users" WHERE "birthYear" = $1 LIMIT 1';
-    break;
-  case 'student':
-    findByQuery = 'SELECT * FROM "users" WHERE "student" = $1 LIMIT 1';
-    break;
+    case 'firstName':
+      findByQuery = 'SELECT * FROM "users" WHERE "firstName" = $1 LIMIT 1';
+      break;
+    case 'lastName':
+      findByQuery = 'SELECT * FROM "users" WHERE "lastName" = $1 LIMIT 1';
+      break;
+    case 'email':
+      findByQuery = 'SELECT * FROM "users" WHERE "email" = $1 LIMIT 1';
+      break;
+    case 'birthYear':
+      findByQuery = 'SELECT * FROM "users" WHERE "birthYear" = $1 LIMIT 1';
+      break;
+    case 'student':
+      findByQuery = 'SELECT * FROM "users" WHERE "student" = $1 LIMIT 1';
+      break;
   }
 
   const value = property[key];

--- a/routes/users.js
+++ b/routes/users.js
@@ -9,6 +9,7 @@ router.post('/', usersController.create);
 
 router.use(verifyLoggedInUser);
 
+router.get('/me', usersController.me);
 router.get('/', usersController.index);
 router.get('/:id', usersController.show);
 

--- a/test/features/users.test.js
+++ b/test/features/users.test.js
@@ -197,4 +197,23 @@ describe('Users', () => {
 
     expect(res.body.user).toEqual({ errors: ['Email already taken'] });
   });
+
+  it('returns logged in user details at /me with valid jwt', async () => {
+    const user = await createUser({ email: 'user1@example.com ' });
+    const token = jwt.sign({ currentUserId: user.id }, process.env.JWT_SECRET);
+
+    const resInvalid = await request(app)
+      .get('/users/me')
+      .set('jwt', token + 'invalid')
+      .expect(404);
+
+    expect(resInvalid.body).toEqual({ error: { status: 404 }, message: 'Not Found' });
+
+    const resValid = await request(app)
+      .get('/users/me')
+      .set('jwt', token)
+      .expect(200);
+
+    expect(resValid.body.user.email).toEqual('user1@example.com');
+  });
 });


### PR DESCRIPTION
### What does this PR do?
This PR is for 
- [x] Instead of storing serialized user in jwt token ,only user id is stored
- [x] `users/me` route that returns the user object for the incoming jwt. valid jwt required, or 404

### Where should someone start to review?
routes/users.js

### How could you test this PR's functionality?
Refer the curl document

~~~### New dependencies?~~~

### Gif of your feels
![alt text](https://media.giphy.com/media/l44Q6Etd5kdSGttXa/giphy.gif)

